### PR TITLE
feat: テーマ登録の下地作成

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,17 +2,25 @@ import "../src/style/index.css";
 
 import type { CustomAppPage } from "next/app";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import { memo } from "react";
 
 const App: CustomAppPage = ({ Component, pageProps }) => {
-  const getLayout = Component.getLayout || ((page) => page);
-
+  const route = useRouter();
   return (
     <>
       <Head>
-        <title>nexst</title>
+        <title>Gorilla Todo</title>
       </Head>
-      {getLayout(<Component {...pageProps} />)}
+      {
+        // TODO ログインしているか検知して、ログインしていなければリダイレクト処理追加する
+        route.route.includes("login") ? (
+          // TODO Login画面作成後、ログイン画面を表示する
+          <></>
+        ) : (
+          <Component {...pageProps} />
+        )
+      }
     </>
   );
 };

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,9 +1,0 @@
-import type { CustomNextPage } from "next";
-import { FixedLayout } from "src/layout";
-import { About } from "src/pages/about";
-
-const AboutPage: CustomNextPage = () => <About />;
-
-AboutPage.getLayout = FixedLayout;
-
-export default AboutPage;

--- a/pages/account/[accountId]/theme/index.tsx
+++ b/pages/account/[accountId]/theme/index.tsx
@@ -1,5 +1,0 @@
-import type { NextPage } from "next";
-
-const Index: NextPage = () => <div>aaavvv</div>;
-
-export default Index;

--- a/pages/account/[accountId]/theme/index.tsx
+++ b/pages/account/[accountId]/theme/index.tsx
@@ -1,0 +1,5 @@
+import type { NextPage } from "next";
+
+const Index: NextPage = () => <div>aaavvv</div>;
+
+export default Index;

--- a/pages/account/[userId]/theme/index.tsx
+++ b/pages/account/[userId]/theme/index.tsx
@@ -1,0 +1,6 @@
+import { Theme } from "@component/theme";
+import type { NextPage } from "next";
+
+const Index: NextPage = () => <Theme />;
+
+export default Index;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,6 @@
 import type { CustomNextPage } from "next";
-import { FluidLayout } from "src/layout";
 import { Index } from "src/pages/index";
 
 const IndexPage: CustomNextPage = () => <Index />;
-
-IndexPage.getLayout = FluidLayout;
 
 export default IndexPage;

--- a/src/component/theme/SelectRow/index.tsx
+++ b/src/component/theme/SelectRow/index.tsx
@@ -1,0 +1,23 @@
+import { useTheme } from "@repo/theme/useTheme";
+import React from "react";
+
+type Props = {
+  children: React.ReactNode;
+  type: string;
+};
+
+export const SelectRow: React.VFC<Props> = ({ children, type }) => {
+  const { onCreate } = useTheme();
+
+  const clickHandler = async () => {
+    await onCreate(type);
+  };
+
+  return (
+    <li>
+      <button className={"py-2 w-full text-left"} onClick={clickHandler}>
+        {children}
+      </button>
+    </li>
+  );
+};

--- a/src/component/theme/Theme.tsx
+++ b/src/component/theme/Theme.tsx
@@ -1,7 +1,35 @@
 import React from "react";
 
+import { SelectRow } from "./SelectRow";
+
+type TThemesTypes = {
+  type: string;
+  label: string;
+};
+
+const themes: TThemesTypes[] = [
+  {
+    type: "os",
+    label: "OSの設定に合わせる",
+  },
+  {
+    type: "light",
+    label: "ライト",
+  },
+  {
+    type: "dark",
+    label: "ダーク",
+  },
+];
+
 export const Theme: React.VFC = () => (
   <div>
-    <p>aaa</p>
+    <ul className={"px-5"}>
+      {themes.map(({ label, type }) => (
+        <SelectRow key={type} type={type}>
+          {label}
+        </SelectRow>
+      ))}
+    </ul>
   </div>
 );

--- a/src/component/theme/Theme.tsx
+++ b/src/component/theme/Theme.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const Theme: React.VFC = () => (
+  <div>
+    <p>aaa</p>
+  </div>
+);

--- a/src/component/theme/index.tsx
+++ b/src/component/theme/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Theme";

--- a/src/repository/theme/themeCollection.ts
+++ b/src/repository/theme/themeCollection.ts
@@ -1,0 +1,1 @@
+export const themeCollection = (userId: string) => `user/${userId}/setting/`;

--- a/src/repository/theme/useTheme.ts
+++ b/src/repository/theme/useTheme.ts
@@ -1,0 +1,25 @@
+import { db } from "@config/firebase";
+import { themeCollection } from "@repo/theme/themeCollection";
+import { doc, setDoc } from "firebase/firestore";
+import { useRouter } from "next/router";
+
+type ThemeActions = {
+  onCreate: (type: string) => Promise<void>;
+};
+
+type Data = {
+  theme: string;
+};
+
+export const useTheme = (): ThemeActions => {
+  const { userId } = useRouter().query;
+
+  const onCreate = async (type: string) => {
+    const data: Data = { theme: type };
+    await setDoc(doc(db, themeCollection(userId as string), "theme"), data);
+  };
+
+  return {
+    onCreate,
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
+      "@config/*": ["./config/*"],
+      "@repo/*": ["./src/repository/*"],
       "@component/*": ["./src/component/*"],
       "@lib/*": ["./src/lib/*"],
       "@hooks/*": ["./src/hooks/*"]


### PR DESCRIPTION
## 内容
アカウント設定のテーマの登録作成

## 動作確認
1. `/account/1/theme` にアクセス
2. 任意のボタンを押下
3. Firestoreで登録を確認

