### PR TITLE
fix: テーマの取得の方法を修正

### DIFF
--- a/src/component/theme/SelectRow/index.tsx
+++ b/src/component/theme/SelectRow/index.tsx
@@ -8,8 +8,7 @@ type Props = {
 
 export const SelectRow: React.VFC<Props> = ({ children, type }) => {
   const { onCreate } = useTheme();
-  const { value } = useGetThemeSetting();
-  const checkedType = value?.docs[0].data().theme;
+  const { selectedTheme } = useGetThemeSetting();
 
   const clickHandler = async () => {
     await onCreate(type);
@@ -20,7 +19,7 @@ export const SelectRow: React.VFC<Props> = ({ children, type }) => {
       <button className={"py-2 w-full text-left"} onClick={clickHandler}>
         {children}
       </button>
-      <div>{checkedType && checkedType === type ? "✔︎" : ""}</div>
+      <div>{selectedTheme && selectedTheme === type ? "✔︎" : ""}</div>
     </li>
   );
 };

--- a/src/repository/theme/useTheme.ts
+++ b/src/repository/theme/useTheme.ts
@@ -1,10 +1,6 @@
 import { db } from "@config/firebase";
 import { themeDoc } from "@repo/theme/themeDoc";
-import type {
-  DocumentData,
-  FirestoreError,
-  QuerySnapshot,
-} from "firebase/firestore";
+import type { FirestoreError } from "firebase/firestore";
 import { collection, doc, setDoc } from "firebase/firestore";
 import { useRouter } from "next/router";
 import { useCollection } from "react-firebase-hooks/firestore";
@@ -18,7 +14,7 @@ type Data = {
 };
 
 export const useGetThemeSetting = (): {
-  value: QuerySnapshot<DocumentData> | undefined;
+  selectedTheme: string;
   loading: boolean;
   error: FirestoreError | undefined;
 } => {
@@ -31,7 +27,14 @@ export const useGetThemeSetting = (): {
     }
   );
 
-  return { value, loading, error };
+  let selectedTheme = "";
+  value?.docs.map((doc) => {
+    if (doc.id === "theme") {
+      selectedTheme = doc?.data().theme;
+    }
+  });
+
+  return { selectedTheme, loading, error };
 };
 
 export const useTheme = (): ThemeActions => {


### PR DESCRIPTION
## 内容
テーマ取得時に配列の0番目のものを取得するようにしていたが
account, profile, themeの三つから取得するようになった場合うまく取得できなくなっていた。

themeだけを取得して、返すように修正しました。

## 動作確認
- [x] テーマの切り替えができること
