### PR TITLE
feat: PostPanelをダークモード対応 #3

### DIFF
--- a/src/component/Panel/PostPanel.tsx
+++ b/src/component/Panel/PostPanel.tsx
@@ -1,3 +1,4 @@
+import { useColorModeValue } from "@chakra-ui/react";
 import { useTodo } from "@repo/todo/useTodo";
 import cc from "classcat";
 import React, { useState } from "react";
@@ -23,6 +24,7 @@ export const PostPanel: React.VFC<PostPanelPropsType> = ({
 }: PostPanelPropsType) => {
   const [textboxValue, setTextboxValue] = useState<string>(value ?? "");
   const { onCreate } = useTodo();
+  const bg = useColorModeValue("bg-white", "bg-[#1A202C]");
 
   // TODO: テキストボックスに入力された値を返すイベント（不要の場合削除）
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -41,7 +43,9 @@ export const PostPanel: React.VFC<PostPanelPropsType> = ({
   };
 
   return (
-    <div className="fixed bottom-0 left-0 py-2 mx-auto w-full h-auto bg-white">
+    <div
+      className={cc(["fixed bottom-0 left-0 py-2 mx-auto w-full h-auto", bg])}
+    >
       <div className="group w-full">
         <div className="group flex justify-center mb-2 space-x-2 w-full">
           <PostTextBox value={textboxValue ?? ""} onChange={handleChange} />


### PR DESCRIPTION
## issue
https://github.com/qin-todo-e-team/qin_gorilla_todo/issues/3

## 内容
PostPanelのダークモード対応

## 動作確認
http://localhost:3000
mac の場合、外観モードをライト、ダークの切り替えにて確認
windowsの場合こちらを参照
https://dekiru.net/article/18558/

# キャプチャ
<img width="471" alt="スクリーンショット 2022-03-05 3 42 28" src="https://user-images.githubusercontent.com/15701307/156823149-27dd95fe-ea52-4033-96ec-0982aadf50f9.png">
<img width="455" alt="スクリーンショット 2022-03-05 3 47 56" src="https://user-images.githubusercontent.com/15701307/156823769-5e4a04a3-c24b-48ff-a6a0-8c379ec3e954.png">


## 備考

## チェックリスト

- [x] PR に label を貼る
- [x] PR に Reviewer を Assign する
- [x] PR の Assignee を自分をにする
