### PR TITLE
feat: プロフィール画面作成

### DIFF
--- a/config/firebase.ts
+++ b/config/firebase.ts
@@ -9,6 +9,7 @@ import {
   signOut,
 } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
@@ -26,6 +27,7 @@ export const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const storage = getStorage(app);
 
 export const provider = new GoogleAuthProvider();
 export const auth = getAuth(app);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,9 @@ const nextConfig = {
   poweredByHeader: false,
   swcMinify: true,
   // experimental: { concurrentFeatures: true, serverComponents: true },
+  images: {
+    domains: ["firebasestorage.googleapis.com"],
+  },
 };
 
 export default nextConfig;

--- a/pages/[userId]/account/profile/index.tsx
+++ b/pages/[userId]/account/profile/index.tsx
@@ -1,0 +1,6 @@
+import type { CustomNextPage } from "next";
+import { Index } from "src/pages/[userId]/account/profile";
+
+const IndexPage: CustomNextPage = () => <Index />;
+
+export default IndexPage;

--- a/src/component/Profile/Profile.tsx
+++ b/src/component/Profile/Profile.tsx
@@ -1,0 +1,84 @@
+import { useProfile } from "@repo/profile/useProfile";
+import Image from "next/image";
+import React from "react";
+
+export const Profile: React.VFC = () => {
+  const {
+    name,
+    imageUrl,
+    nameRequired,
+    loading,
+    imageRef,
+    onChangeName,
+    onChangeImage,
+    onClickOpenFileDialog,
+    onClickFileUpLoad,
+  } = useProfile();
+
+  return (
+    <div className="px-6 mx-auto w-full max-w-screen-sm">
+      <div className="mt-6">
+        <label htmlFor="image" className="text-sm font-bold text-[#C2C6D2]">
+          アイコン
+        </label>
+        <div className="flex items-center mt-2 space-x-6">
+          {imageUrl ? (
+            <Image
+              src={imageUrl}
+              alt=""
+              width={96}
+              height={96}
+              className="object-cover object-center w-24 h-24 rounded-full"
+            />
+          ) : (
+            <div className="w-24 h-24 bg-[#C2C6D2] rounded-full"></div>
+          )}
+          <input
+            ref={imageRef}
+            type="file"
+            id="image"
+            onChange={onChangeImage}
+            className="hidden"
+            accept="image/*"
+          />
+          <button
+            onClick={onClickOpenFileDialog}
+            className="py-2.5 px-4 text-xs font-bold text-[#070417] bg-slate-100 rounded-full"
+          >
+            変更する
+          </button>
+        </div>
+      </div>
+      <div className="mt-6">
+        <label htmlFor="name" className="text-sm font-bold text-[#C2C6D2]">
+          名前
+        </label>
+        <input
+          type="text"
+          id="name"
+          value={name}
+          onChange={onChangeName}
+          className="block py-3.5 px-4 mt-2 w-full text-sm text-[#070417] bg-slate-100 rounded-2xl border-none"
+        />
+        {nameRequired && (
+          <p className="mt-0.5 ml-4 text-sm text-red-500">入力必須です</p>
+        )}
+        {loading ? (
+          <button
+            onClick={onClickFileUpLoad}
+            className="p-4 mt-9 w-full text-xs font-bold text-white bg-blue-400 rounded-full"
+          >
+            保存中
+          </button>
+        ) : (
+          <button
+            onClick={onClickFileUpLoad}
+            className="p-4 mt-9 w-full text-xs font-bold text-white bg-blue-500 rounded-full"
+          >
+            保存する
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/component/Profile/index.tsx
+++ b/src/component/Profile/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Profile";

--- a/src/pages/[userId]/account/profile/index.tsx
+++ b/src/pages/[userId]/account/profile/index.tsx
@@ -1,0 +1,9 @@
+import { SettingLayout } from "@component/Layout/setting";
+import { Profile } from "@component/Profile";
+import React from "react";
+
+export const Index: React.VFC = () => (
+  <SettingLayout title={"プロフィール"}>
+    <Profile />
+  </SettingLayout>
+);

--- a/src/repository/profile/profileDoc.ts
+++ b/src/repository/profile/profileDoc.ts
@@ -1,0 +1,3 @@
+export const profileDoc = (userId: string) => `user/${userId}/setting/`;
+export const profileRef = (userId: string) =>
+  `user/${userId}/setting/profile/${userId}`;

--- a/src/repository/profile/useProfile.ts
+++ b/src/repository/profile/useProfile.ts
@@ -1,0 +1,97 @@
+import { db, storage } from "@config/firebase";
+import { profileDoc, profileRef } from "@repo/profile/profileDoc";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
+import { useRouter } from "next/router";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+
+export const useProfile = () => {
+  const [name, setName] = useState<string>("");
+  const [image, setImage] = useState<File | null | undefined>();
+  const [imageUrl, setImageUrl] = useState<string>("");
+  const [nameRequired, setNameRequired] = useState(false);
+  const [loading, setLoding] = useState(false);
+  const imageRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+  const { userId } = router.query;
+
+  useEffect(() => {
+    if (router.isReady) {
+      (async () => {
+        const docRef = doc(db, profileDoc(userId as string), "profile");
+        const docSnap = await getDoc(docRef);
+
+        if (docSnap.exists()) {
+          const { name, url } = docSnap.data();
+          setImageUrl(url);
+          setName(name);
+        }
+      })();
+    }
+  }, [router, userId]);
+
+  const onClickOpenFileDialog = () => {
+    imageRef.current?.click();
+  };
+
+  const onChangeImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.item(0);
+    const sizeLimit = 1024 * 1024 * 1;
+    if (!file) {
+      return;
+    }
+
+    if (sizeLimit < file.size) {
+      alert("ファイルサイズは1MB以下にしてください");
+      e.target.value = "";
+      return;
+    }
+
+    const url = URL.createObjectURL(file);
+    setImage(file);
+    setImageUrl(url);
+  };
+
+  const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+  };
+
+  const onClickFileUpLoad = async () => {
+    setLoding(true);
+    if (image) {
+      const storageRef = ref(storage, profileRef(userId as string));
+      const snapshot = await uploadBytes(storageRef, image);
+      const url = await getDownloadURL(snapshot.ref);
+
+      await setDoc(
+        doc(db, profileDoc(userId as string), "profile"),
+        { url: url },
+        { merge: true }
+      );
+    }
+    if (name) {
+      await setDoc(
+        doc(db, profileDoc(userId as string), "profile"),
+        { name: name },
+        { merge: true }
+      );
+      setNameRequired(false);
+    } else {
+      setNameRequired(true);
+    }
+    setLoding(false);
+  };
+
+  return {
+    name,
+    imageUrl,
+    nameRequired,
+    loading,
+    imageRef,
+    onChangeName,
+    onChangeImage,
+    onClickOpenFileDialog,
+    onClickFileUpLoad,
+  };
+};


### PR DESCRIPTION
## 内容
アカウント設定のプロフィール登録作成

## 動作確認
1./1/account/profileにアクセス
2.変更するボタンを押下して画像ファイルを選択
3.名前テキストフィールドに入力
4.保存するボタンを押下
5.FirestoreとStorageで登録を確認
6.ページを再読み込みして登録された画像と名前が反映されていることを確認

# キャプチャ
https://user-images.githubusercontent.com/30023315/157260210-29d3d8f7-25f0-4e96-941c-a7fa24a8bd7e.mov

## 備考
アイコンと名前はそれぞれ片方ずつ登録可能です。
アイコン画像は1MB以下までしかアップロードできません。
名前は入力必須となります。
